### PR TITLE
Turn off SSL Verification

### DIFF
--- a/app/models/coursera.rb
+++ b/app/models/coursera.rb
@@ -1,6 +1,7 @@
 class Coursera
   include HTTParty
 
+  default_options.update(verify: false) # Turn off SSL verification
   base_uri 'https://api.coursera.org/api/catalog.v1/courses'
   default_params fields: "smallIcon,shortDescription", q: "search"
   format :json


### PR DESCRIPTION
Coursera API is a HTTPS url. So we need to turn off SSL verification, unless the user imports the cert into their trust store..
